### PR TITLE
Null the parent and child

### DIFF
--- a/src/05_objects/_lists.scss
+++ b/src/05_objects/_lists.scss
@@ -21,6 +21,7 @@
     }
 
     &--nulled {
+        &,
         .list__item {
             margin: 0;
         }


### PR DESCRIPTION
Let's take this from v1.5.0 as a patch to the current releases.