### PR TITLE
BUGFIX: fix "breakpoint-max" generating invalid CSS

### DIFF
--- a/src/02_tools/_breakpoints.scss
+++ b/src/02_tools/_breakpoints.scss
@@ -15,9 +15,9 @@
   }
 }
 
-@mixin breakpoint-max($breakpoint) { 
+@mixin breakpoint-max($breakpoint) {
   @if map-has-key($breakpoints, $breakpoint) {
-    $val: number( #{map-get($breakpoints, $breakpoint)} ) - rem(1px);
+    $val: #{map-get($breakpoints, $breakpoint)} - em(1px);
     @media (max-width: ( $val ) ) {
       @content;
     }


### PR DESCRIPTION
Due to using a nonexistent (at least on my machine and sass version, node-sass 3.8.0, libsass 3.3.6) `number()` function, the `breakpoint-max` mixin generated invalid CSS (`number(foo)` was passed through to CSS). Fixed it by removing the function and outputting the result in em, similar to the `breakpoint-min` mixin.