### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Or, you can install via [npm](http://npmjs.org):
 ```
 $ npm install --save tent-css
 ```
+
+Or, you can include it via [CDN](https://www.jsdelivr.com/package/npm/tent-css):
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tent-css/dist/tent.css">
+```
+
 Or, you can clone the source:
 
 ```


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/tent-css) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.